### PR TITLE
Fix bootstrap, Popper.js dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Bootstrap need the following packages:
 
 ### Add packages with Yarn
 ```
-Yarn add bootstrap jquery
+Yarn add bootstrap jquery popper.js
 ```
 
 ### Add new dependencies to Webpack

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-loader": "^8.2.2",
     "bootstrap": "^4.6.0",
     "jquery": "^3.6.0",
+    "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5209,6 +5209,11 @@ pnp-webpack-plugin@^1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
 portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"


### PR DESCRIPTION
Bootstrap requires `popper.js` in its dependencies, by the way in the `environment.js` is not included.